### PR TITLE
export getVisibleIndexData

### DIFF
--- a/lib/src/flutter_sliver_list_controller.dart
+++ b/lib/src/flutter_sliver_list_controller.dart
@@ -66,4 +66,8 @@ class FlutterSliverListController {
   void dispose() {
     stickyIndex.dispose();
   }
+
+  List<dynamic>? getVisibleIndexData() {
+    return _listView?.getVisibleIndexData();
+  }
 }


### PR DESCRIPTION
This PR exports the getVisibleIndexData function to provide access to the currently visible index.